### PR TITLE
Test folder creation via processDirectoryStructure()

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@simplyhexagonal/exec": "2.0.2",
     "@simplyhexagonal/logger": "2.1.1",
     "@simplyhexagonal/mono-context": "1.1.2",
+    "@types/yargs": "^17.0.10",
     "dotenv": "16.0.1",
     "fs-extra": "10.1.0",
     "ora": "6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@simplyhexagonal/elean': 1.0.0
@@ -9,6 +9,7 @@ specifiers:
   '@types/jest': 28.1.3
   '@types/node': 18.0.0
   '@types/promise-ftp': 1.3.4
+  '@types/yargs': ^17.0.10
   dotenv: 16.0.1
   esbuild: 0.14.47
   fs-extra: 10.1.0
@@ -24,9 +25,10 @@ specifiers:
 
 dependencies:
   '@simplyhexagonal/elean': 1.0.0
-  '@simplyhexagonal/exec': 2.0.2_be2e1aa100fa66c69178c97dcbe86956
+  '@simplyhexagonal/exec': 2.0.2_xyxbviia7jtmnelyzf64x2djky
   '@simplyhexagonal/logger': 2.1.1
   '@simplyhexagonal/mono-context': 1.1.2
+  '@types/yargs': 17.0.10
   dotenv: 16.0.1
   fs-extra: 10.1.0
   ora: 6.1.1
@@ -39,10 +41,10 @@ devDependencies:
   '@types/node': 18.0.0
   '@types/promise-ftp': 1.3.4
   esbuild: 0.14.47
-  jest: 28.1.1_48599dd56573cc70f5830486390ee5cc
+  jest: 28.1.1_jbmz3vlfopghb5mdasddsdxfzq
   nodemon: 2.0.18
-  ts-jest: 28.0.5_10eeba5265f8ae2ffe3f402068e91b6e
-  ts-node: 10.8.1_82302fe81736abce5d7cc3aa06eabded
+  ts-jest: 28.0.5_cdxluutf7cxc77r7iaqgr2i3ny
+  ts-node: 10.8.1_qiyc72axg2v44xl4yovan2v55u
   tslib: 2.4.0
   typescript: 4.7.4
 
@@ -209,6 +211,8 @@ packages:
     resolution: {integrity: sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.18.4
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.18.5:
@@ -433,7 +437,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 28.0.2
-      jest-config: 28.1.1_48599dd56573cc70f5830486390ee5cc
+      jest-config: 28.1.1_jbmz3vlfopghb5mdasddsdxfzq
       jest-haste-map: 28.1.1
       jest-message-util: 28.1.1
       jest-regex-util: 28.0.2
@@ -663,7 +667,7 @@ packages:
     resolution: {integrity: sha512-z0llp14xha73yxI5TDVWM5k+PXeRcjSYu4svQriEnoyhRCPZgDMpObXYSDMKVPr+SP7qg5tUGu6+1seCmpfJZw==}
     dev: false
 
-  /@simplyhexagonal/exec/2.0.2_be2e1aa100fa66c69178c97dcbe86956:
+  /@simplyhexagonal/exec/2.0.2_xyxbviia7jtmnelyzf64x2djky:
     resolution: {integrity: sha512-3RN7sCrn2wfA2K2kdlt2BNn9Ajb9ko9dkJXecQoJyDG732fcBnzNNpni6vHtMtROrAHuNpmMTQCSMt7eVGK+vw==}
     peerDependencies:
       '@simplyhexagonal/elean': ^1.0.0
@@ -804,6 +808,12 @@ packages:
       pretty-format: 28.1.1
     dev: true
 
+  /@types/keyv/3.1.4:
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+    dependencies:
+      '@types/node': 18.0.0
+    dev: true
+
   /@types/node/18.0.0:
     resolution: {integrity: sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==}
 
@@ -824,6 +834,12 @@ packages:
       '@types/promise-ftp-common': 1.1.0
     dev: true
 
+  /@types/responselike/1.0.0:
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
+    dependencies:
+      '@types/node': 18.0.0
+    dev: true
+
   /@types/stack-utils/2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
@@ -836,13 +852,11 @@ packages:
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
-    dev: true
 
   /@types/yargs/17.0.10:
     resolution: {integrity: sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==}
     dependencies:
       '@types/yargs-parser': 21.0.0
-    dev: true
 
   /abbrev/1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -1278,10 +1292,16 @@ packages:
     resolution: {integrity: sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==}
     dev: false
 
-  /debug/3.2.7:
+  /debug/3.2.7_supports-color@5.5.0:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
+      supports-color: 5.5.0
     dev: true
 
   /debug/4.3.4:
@@ -1765,6 +1785,8 @@ packages:
     dependencies:
       '@sindresorhus/is': 0.14.0
       '@szmarczak/http-timer': 1.1.2
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
@@ -2045,7 +2067,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/28.1.1_48599dd56573cc70f5830486390ee5cc:
+  /jest-cli/28.1.1_jbmz3vlfopghb5mdasddsdxfzq:
     resolution: {integrity: sha512-+sUfVbJqb1OjBZ0OdBbI6OWfYM1i7bSfzYy6gze1F1w3OKWq8ZTEKkZ8a7ZQPq6G/G1qMh/uKqpdWhgl11NFQQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -2062,7 +2084,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 28.1.1_48599dd56573cc70f5830486390ee5cc
+      jest-config: 28.1.1_jbmz3vlfopghb5mdasddsdxfzq
       jest-util: 28.1.1
       jest-validate: 28.1.1
       prompts: 2.4.2
@@ -2073,7 +2095,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config/28.1.1_48599dd56573cc70f5830486390ee5cc:
+  /jest-config/28.1.1_jbmz3vlfopghb5mdasddsdxfzq:
     resolution: {integrity: sha512-tASynMhS+jVV85zKvjfbJ8nUyJS/jUSYZ5KQxLUN2ZCvcQc/OmhQl2j6VEL3ezQkNofxn5pQ3SPYWPHb0unTZA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     peerDependencies:
@@ -2108,7 +2130,7 @@ packages:
       pretty-format: 28.1.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.8.1_82302fe81736abce5d7cc3aa06eabded
+      ts-node: 10.8.1_qiyc72axg2v44xl4yovan2v55u
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2397,7 +2419,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/28.1.1_48599dd56573cc70f5830486390ee5cc:
+  /jest/28.1.1_jbmz3vlfopghb5mdasddsdxfzq:
     resolution: {integrity: sha512-qw9YHBnjt6TCbIDMPMpJZqf9E12rh6869iZaN08/vpOGgHJSAaLLUn6H8W3IAEuy34Ls3rct064mZLETkxJ2XA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -2410,7 +2432,7 @@ packages:
       '@jest/core': 28.1.1_ts-node@10.8.1
       '@jest/types': 28.1.1
       import-local: 3.1.0
-      jest-cli: 28.1.1_48599dd56573cc70f5830486390ee5cc
+      jest-cli: 28.1.1_jbmz3vlfopghb5mdasddsdxfzq
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -2595,7 +2617,7 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 3.5.3
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@5.5.0
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
@@ -3128,7 +3150,7 @@ packages:
       nopt: 1.0.10
     dev: true
 
-  /ts-jest/28.0.5_10eeba5265f8ae2ffe3f402068e91b6e:
+  /ts-jest/28.0.5_cdxluutf7cxc77r7iaqgr2i3ny:
     resolution: {integrity: sha512-Sx9FyP9pCY7pUzQpy4FgRZf2bhHY3za576HMKJFs+OnQ9jS96Du5vNsDKkyedQkik+sEabbKAnCliv9BEsHZgQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -3149,7 +3171,7 @@ packages:
       bs-logger: 0.2.6
       esbuild: 0.14.47
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.1_48599dd56573cc70f5830486390ee5cc
+      jest: 28.1.1_jbmz3vlfopghb5mdasddsdxfzq
       jest-util: 28.1.1
       json5: 2.2.1
       lodash.memoize: 4.1.2
@@ -3159,7 +3181,7 @@ packages:
       yargs-parser: 21.0.1
     dev: true
 
-  /ts-node/10.8.1_82302fe81736abce5d7cc3aa06eabded:
+  /ts-node/10.8.1_qiyc72axg2v44xl4yovan2v55u:
     resolution: {integrity: sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==}
     hasBin: true
     peerDependencies:

--- a/src/fixtures/project-structure.json
+++ b/src/fixtures/project-structure.json
@@ -76,7 +76,7 @@
         },
         {
           "name": "content-from-s3",
-          "flags": ["must-store"],
+          "flags": ["must-skip"],
           "contentSources": [
             {
               "sourcePath": "s3://static.xtld.stream/content-samples",
@@ -86,6 +86,7 @@
         },
         {
           "name": "content-from-tar",
+          "flags": [ "must-skip" ],
           "contentSources": [
             {
               "sourcePath": "./content-from-s3/archive/tape-archive/text-files-and-sub-dir.tar",
@@ -95,7 +96,7 @@
         },
         {
           "name": "content-from-tgz",
-          "flags": ["must-store"],
+          "flags": [ "must-skip" ],
           "contentSources": [
             {
               "sourcePath": "./content-from-s3/archive/tape-archive-gunzip/text-files-and-sub-dir.tgz",
@@ -105,6 +106,7 @@
         },
         {
           "name": "content-from-zip",
+          "flags": [ "must-skip" ],
           "contentSources": [
             {
               "sourcePath": "./content-from-s3/archive/compressed-files/document-and-video.zip",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -45,7 +45,7 @@ describe('index', () => {
     // ACT
     const result = await processDirectoryStructure(
       {
-        rootWorkingDirectory: './testfiles/empty-dir',
+        rootWorkingDirectory: './testfiles',
         directoryStructure: emptyDirStructure,
       }
     );
@@ -64,7 +64,7 @@ describe('index', () => {
     // ACT
     const result = await processDirectoryStructure(
       {
-        rootWorkingDirectory: './testfiles/content-dir/content-from-ftp',
+        rootWorkingDirectory: './testfiles/content-dir',
         directoryStructure: contentFromFTPDirStructure,
       }
     );

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,3 +1,4 @@
+import fs from "fs";
 import {
   ensureDirSync,
   copyFileSync,
@@ -60,6 +61,7 @@ describe('index', () => {
     const contentDirStructure = projectStructure.directoryStructure.filter((directory) => directory["name"] === "content-dir") as DirectoryStructure
     const contentFromFTPDirStructure = contentDirStructure[0]["directories"]!.filter((subdirectory) => subdirectory["name"] === "content-from-ftp") as DirectoryStructure    
     const contentSources = contentFromFTPDirStructure[0]["contentSources"]![0] as ContentSource
+    const storageDirectory = "testfiles/content-dir/content-from-ftp";
 
     // ACT
     const result = await processDirectoryStructure(
@@ -70,8 +72,12 @@ describe('index', () => {
     );
       
     // ASSERT
+    let files = fs.readdirSync(`${storageDirectory}/repodata`);
+    console.log(files);
+    expect(files.length).toBeGreaterThan(0); // Expect folder to be populated
+
     console.log(result);
     result.map(item => expect(item.success).toBe(true));
-    expect(contentSources["sourceType"]).toBe("ftp")
+    expect(contentSources["sourcePath"]).toBe("ftp://ubuntu.osuosl.org/pub/elrepo/extras/el9/SRPMS")
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,7 +9,7 @@ import Logger from '@simplyhexagonal/logger';
 import projectStructure from './fixtures/project-structure.json';
 
 import { processDirectoryStructure } from './';
-import { DirectoryStructure } from './interfaces';
+import { DirectoryStructure, ContentSource } from './interfaces';
 
 beforeAll(() => {
   ensureDirSync('/tmp/make-dir-structure');
@@ -53,5 +53,25 @@ describe('index', () => {
     // ASSERT
     console.log(result);
     expect(result[0].success).toBe(true);
+  });
+  
+  it('creates /testfiles/content-dir/content-from-ftp and downloads its content', async () => {
+    // ARRANGE
+    const contentDirStructure = projectStructure.directoryStructure.filter((directory) => directory["name"] === "content-dir") as DirectoryStructure
+    const contentFromFTPDirStructure = contentDirStructure[0]["directories"]!.filter((subdirectory) => subdirectory["name"] === "content-from-ftp") as DirectoryStructure    
+    const contentSources = contentFromFTPDirStructure[0]["contentSources"]![0] as ContentSource
+
+    // ACT
+    const result = await processDirectoryStructure(
+      {
+        rootWorkingDirectory: './testfiles/content-dir/content-from-ftp',
+        directoryStructure: contentFromFTPDirStructure,
+      }
+    );
+      
+    // ASSERT
+    console.log(result);
+    result.map(item => expect(item.success).toBe(true));
+    expect(contentSources["sourceType"]).toBe("ftp")
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,4 +36,22 @@ describe('index', () => {
 
     expect(true).toBe(true);
   });
+
+  it('creates a single /empty-dir inside /testfiles', async () => {
+    // ARRANGE
+    const emptyDirStructure = projectStructure.directoryStructure.filter((directory) => directory["name"] === "empty-dir") as DirectoryStructure
+    // const emptyDirStructure = projectStructure.directoryStructure.filter((directory) => directory["directories"] === undefined || directory["directories"] === []) as DirectoryStructure
+    
+    // ACT
+    const result = await processDirectoryStructure(
+      {
+        rootWorkingDirectory: './testfiles/empty-dir',
+        directoryStructure: emptyDirStructure,
+      }
+    );
+    
+    // ASSERT
+    console.log(result);
+    expect(result[0].success).toBe(true);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 import { hideBin } from 'yargs/helpers';
-import MonoContext from '@simplyhexagonal/mono-context';import yargs from 'yargs';
+import MonoContext from '@simplyhexagonal/mono-context';
+import yargs from 'yargs';
 import Logger from '@simplyhexagonal/logger';
 
 import { commands } from './commands';


### PR DESCRIPTION
# What was done in this PR by @eduardosancho 🎃 :

> Closes issues #1, #2 , #3
> Once again, thanks for the detailed instructions on all of the issues, it has been truly useful.

- [x] Add test to check if testfiles/empty-dir was created.
- [x] Add test to check if testfiles/content-dir/content-from-ftp was created and log where it's contents come from.

## Questions
* ### How can I fix an error when trying to access data to the AWS S3?
The first test that checks the entire structure of /testfiles, returns the following error message for AWS S3 which causes other error messages down the line saying "No such file or directory" when looking for any sourcePath pointing to AWS S3. 
![image](https://user-images.githubusercontent.com/53308506/176786821-8a32a713-a5d2-42a8-84a7-abdfa39a5f0f.png)
> Also, it's `expect` has been [hardcoded](https://github.com/simplyhexagonal/project-structure/blob/c9284a272bf24e8e3c651157eafe32eeeaca0c48/src/index.test.ts#L37) to always pass the test.

* ## Could you please provide insights on how to test the downloaded content of `/content-from-ftp`?
The test to verify that `/content-from-ftp` folder was created successfully is not checking the content of the folder in `/testfiles`, instead it's dependent on the success message that is returned.
I'm currently trying to use `Watch Plugins` for this.
<hr>

<img src="https://media0.giphy.com/media/zOvBKUUEERdNm/giphy.gif"/>